### PR TITLE
Added Travis CI configuration for Linux clang/gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c
+
+os:
+  - linux
+
+compiler: 
+  - clang
+  - gcc
+
+before_script:  
+    - mkdir build
+    - cd build
+    - cmake ..
+
+script: 
+  - make 
+  - make test


### PR DESCRIPTION
This adds a Travis CI configuration for building on Linux with clang and gcc. We can get automatic testing of branches and pull requests if this is added and someone with the correct access activates [Travis CI](http://travis-ci.org) for the the FMUComplicanceChecker repository.

In the long run one could enable automatic building of releases, enabling testing of macOS (currently they seem to have some performance/throughput issues with their macOS infrastructure).