### PR TITLE
Format time with the same precision as other reals

### DIFF
--- a/src/FMI2/fmi2_check.c
+++ b/src/FMI2/fmi2_check.c
@@ -364,7 +364,7 @@ jm_status_enu_t fmi2_write_csv_data(fmu_check_data_t* cdata, double time) {
 		sprintf(fmt_false, "%c0", cdata->CSV_separator);
 	}
 
-	if(checked_fprintf(cdata, "%g", time) != jm_status_success) {
+	if(checked_fprintf(cdata, "%.16E", time) != jm_status_success) {
 		return jm_status_error;
 	}
 


### PR DESCRIPTION
This is already done for fmi1. It makes it possible to distinguish
the small micro step at then end (which is a bug in it self) from an
event when fmuCheck is run with -d.