### PR TITLE
Incorrect instance name initialized in cdata structure Issue #46

### DIFF
--- a/src/FMI2/fmi2_cs_sim.c
+++ b/src/FMI2/fmi2_cs_sim.c
@@ -34,7 +34,7 @@ jm_status_enu_t fmi2_cs_simulate(fmu_check_data_t* cdata)
 
     prepare_time_step_info(cdata, &tend, &hstep);
 
-	cdata->instanceNameToCompare = "Test FMI 2.0 CS";
+    cdata->instanceNameToCompare = fmi2_import_get_model_identifier_CS(fmu);
 	cdata->instanceNameSavedPtr = 0;
 	jmstatus = fmi2_import_instantiate(fmu, cdata->instanceNameToCompare, fmi2_cosimulation, 0, visible);
 

--- a/src/FMI2/fmi2_me_sim.c
+++ b/src/FMI2/fmi2_me_sim.c
@@ -80,7 +80,7 @@ jm_status_enu_t fmi2_me_simulate(fmu_check_data_t* cdata)
 	}
 
 	cdata->instanceNameSavedPtr = 0;
-	cdata->instanceNameToCompare = "Test FMI 2.0 ME";
+    cdata->instanceNameToCompare = fmi2_import_get_model_identifier_CS(fmu);
 
 	jmstatus = fmi2_import_instantiate(fmu, cdata->instanceNameToCompare,fmi2_model_exchange,0,0);
 


### PR DESCRIPTION
In line 37 in file fmi2_cs_sim.c, instanceNameToCompare initialized with incorrect value "Test FMI2.0 CS". The value is not overwritten anywhere again and thus I get a runtime error while using compliance checker. Should be initialized as in the attached file line 37
and then the compliance checker works fine.